### PR TITLE
Fix jsx-runtime and add Rask node types

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rask-ui",
-  "version": "0.29.4",
+  "version": "0.30.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/core/src/jsx-runtime.ts
+++ b/packages/core/src/jsx-runtime.ts
@@ -1,14 +1,5 @@
-// JSX runtime for TypeScript type checking
-// The actual JSX transformation is done by SWC plugin at build time
-// This file only provides type declarations for TypeScript's "jsx": "react-jsx" mode
-
-// Import inferno to get the global JSX namespace
-import "inferno";
-
-// Re-export Fragment for JSX fragment syntax
-export { Fragment } from "inferno";
-
-// Type declarations for jsx/jsxs functions (never called at runtime)
-// TypeScript uses these signatures for JSX type checking
-export declare function jsx(type: any, props: any, key?: any): any;
-export declare function jsxs(type: any, props: any, key?: any): any;
+// JSX runtime stub for TypeScript's "jsx": "react-jsx" mode
+// The actual JSX transformation is done by the SWC plugin at build time,
+// but Vite's dependency optimizer resolves and bundles this module at runtime,
+// so we need real exports (not just type declarations) to avoid missing export errors
+export { Fragment, createVNode as jsx, createVNode as jsxs } from "inferno";

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -40,6 +40,8 @@ declare global {
     export type FocusEvent<T = Element> = InfernoFocusEvent<T>;
     export type FormEvent<T = Element> = InfernoFormEvent<T>;
     export type CompositionEvent<T = Element> = InfernoCompositionEvent<T>;
+    export type Children = InfernoNode;
+    export type RaskNode = InfernoNode;
     export type ElementProps<T extends keyof JSX.IntrinsicElements> = Omit<
       JSX.IntrinsicElements[T],
       keyof Inferno.Attributes


### PR DESCRIPTION
## Summary
- Fix jsx-runtime to export real functions (`jsx`, `jsxs`, `Fragment`) for Vite compatibility instead of type-only declarations
- Add `Rask.Children` and `Rask.RaskNode` type aliases for `InfernoNode` (equivalent to React's `ReactNode`)

## Test plan
- [ ] Verify Vite dev server resolves jsx-runtime without missing export errors
- [ ] Verify `Rask.Children` and `Rask.RaskNode` types work in component props

🤖 Generated with [Claude Code](https://claude.com/claude-code)